### PR TITLE
First stab at a fix for subl:// protocol

### DIFF
--- a/play-framework-chrome-tools.js
+++ b/play-framework-chrome-tools.js
@@ -23,10 +23,19 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "playEditorURL"}, 
 			var line = lineMatch[1];
 
 			var editorInvocationURL = playEditorURL.replace('$file', file).replace('$line', line);
-			document.body.innerHTML = document.body.innerHTML.replace(filePattern, "<span style='color: #FFA500; text-decoration: underline; cursor: pointer;' id='openInEditor'>" + file + "</span>");
+			var id = 'openInEditorAjax';
+			if (editorInvocationURL.indexOf('http') == -1) {
+				id = 'openInEditor';
+			}
+			document.body.innerHTML = document.body.innerHTML.replace(filePattern, "<span style='color: #FFA500; text-decoration: underline; cursor: pointer;' id='" + id + "'>" + file + "</span>");
 
-			$('#openInEditor').on('click', function() {
+
+
+			$('#openInEditorAjax').on('click', function() {
 				$.get(editorInvocationURL);
+			});
+			$('#openInEditor').on('click', function() {
+				window.open(editorInvocationURL, '_blank');
 			});
 		}
 	}


### PR DESCRIPTION
When a editor URL does not have an HTTP handler, we can't seem to open it via AJAX (and thus avoiding a new tab to be opened). Until we find a workaround for it, we open the URL in _blank (new tab).
