### PR TITLE
Activate the error linking only when necessary

### DIFF
--- a/play-framework-chrome-tools.js
+++ b/play-framework-chrome-tools.js
@@ -17,8 +17,7 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "playEditorURL"}, 
 
 		var fileMatch = document.body.textContent.match(filePattern);
 		var lineMatch = document.body.textContent.match(linePattern);
-
-		if(fileMatch) {
+		if(fileMatch && lineMatch) {
 			var file = fileMatch[1];
 			var line = lineMatch[1];
 


### PR DESCRIPTION
When e.g. on a page that contains a "Lorem Ipsum" text, the plugin would activate as well
