### PR TITLE
#11 Use window.reload() to enable reloading with hash-based URLs

### DIFF
--- a/src/play-framework-chrome-tools.js
+++ b/src/play-framework-chrome-tools.js
@@ -12,13 +12,14 @@ $( document ).ready(function() {
 });
 
 // Play Auto Refresh
-var ws = new WebSocket("ws://localhost:9001")
+var ws = new WebSocket("ws://localhost:9001");
 ws.onmessage = function(event) {
     if (event.data == "reload") {
-        window.location = window.location.href
-        ws.close()
+//        window.location = window.location.href
+        window.location.reload();
+        ws.close();
     }
-}
+};
 
 // Open in editor
 var filePattern = /In ([^ ]+)/;


### PR DESCRIPTION
Yay, reload() works with hash-based urls.
